### PR TITLE
Small fix to build package in Debian Squeeze

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,3 +28,10 @@ Section: debug
 Depends: ${shlibs:Depends}, ${misc:Depends}, libswarm2 (= ${binary:Version})
 Description: Rift is an HTTP access point to elliptics distributed network (debug)
  Debug files and symbols.
+
+Package: librift-dbg
+Architecture: any
+Section: debug
+Depends: ${shlibs:Depends}, ${misc:Depends}, libswarm2 (= ${binary:Version})
+Description: Rift is an HTTP access point to elliptics distributed network (debug)
+ Debug files and symbols.


### PR DESCRIPTION
Fix this:

dh_strip: debug package librift-dbg is not listed in the control file
make: **\* [binary-strip-IMPL/rift] Error 9
dpkg-buildpackage: error: fakeroot debian/rules binary gave error exit status 2
debuild: fatal error at line 1325:

cp: cannot stat `README': No such file or directory
dh_installdocs: cp -a README debian/rift/usr/share/doc/rift returned exit code 1
make: **\* [binary-install/rift] Error 2
